### PR TITLE
Update validEmailAddr() usage

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -115,7 +115,7 @@ class SmtpMailer extends Mailer {
 			$this->mailer->ClearAddresses();
 			$this->mailer->AddAddress($to_splitted[3], $to_splitted[2]); 
 		} else {
-			$to = validEmailAddr($to);
+			$to = $this->validEmailAddr($to);
 			$this->mailer->ClearAddresses();
 			$this->mailer->AddAddress($to, ucfirst(substr($to, 0, strpos($to, '@')))); 
 			//For the recipient's name, the string before the @ from the e-mail address is used


### PR DESCRIPTION
validEmailAddr() is deprecated, so updated to be $this->validEmailAddr().  This is for SS 3.0.5.
