### PR TITLE
BUGFIX: correct return values and clean up code

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -55,12 +55,12 @@ class SmtpMailer extends Mailer {
 			$this->mailer->MsgHTML($htmlContent, Director::baseFolder());
 		} else {
 			$this->mailer->Body = $htmlContent;
-      if(empty($plainContent)){
-        $plainContent = trim(Convert::html2raw($htmlContent));
-      }
-      $this->mailer->AltBody = $plainContent;
+			if(empty($plainContent)){
+				$plainContent = trim(Convert::html2raw($htmlContent));
+			}
+			$this->mailer->AltBody = $plainContent;
 		}
-		$this->sendMailViaSmtp($to, $from, $subject, $attachedFiles, $customheaders, $inlineImages);
+		return $this->sendMailViaSmtp($to, $from, $subject, $attachedFiles, $customheaders, $inlineImages);
 	}
 
 
@@ -89,6 +89,8 @@ class SmtpMailer extends Mailer {
 				echo "<em><strong>*** The debug mode blocked the process</strong> to avoid the url redirection. So the CC e-mail is not sent.</em>";
 				die();
 			}
+			
+			return true; // return true if everything worked.
 
 		} catch(phpmailerException $pe){
 			$this->handleError($pe->errorMessage(), $msgForLog);
@@ -146,7 +148,7 @@ class SmtpMailer extends Mailer {
 	protected function attachFiles($attachedFiles){
 		if(!empty($attachedFiles) && is_array($attachedFiles)){
 			foreach($attachedFiles as $attachedFile){
-        if(substr($attachedFile['filename'], 0, strlen(Director::baseFolder())) === Director::baseFolder()){ // If the file path is already included, don't include it again
+				if(substr($attachedFile['filename'], 0, strlen(Director::baseFolder())) === Director::baseFolder()){ // If the file path is already included, don't include it again
 					$filePath = $attachedFile['filename'];
 				} else {
 					$filePath = Director::baseFolder() . DIRECTORY_SEPARATOR . $attachedFile['filename'];


### PR DESCRIPTION
The return values were missing, indicating whether the email could be sent. Along with that I have just cleaned up some indents.
