### PR TITLE
Replaces deprecated function validEmailAddr() with Email::validEmailAddress()

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -117,7 +117,7 @@ class SmtpMailer extends Mailer {
 			$this->mailer->ClearAddresses();
 			$this->mailer->AddAddress($to_splitted[3], $to_splitted[2]); 
 		} else {
-			$to = validEmailAddr($to);
+			$to = Email::validEmailAddress($to);
 			$this->mailer->ClearAddresses();
 			$this->mailer->AddAddress($to, ucfirst(substr($to, 0, strpos($to, '@')))); 
 			//For the recipient's name, the string before the @ from the e-mail address is used


### PR DESCRIPTION
Email::validEmailAddress is existing in SilverStripe 2.3 already and is used nowadays in SilverStripe versions.
