### PR TITLE
handleError now uses SilverStripe Error Handling

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -116,7 +116,6 @@ class SmtpMailer extends Mailer {
 			$this->mailer->ClearAddresses();
 			$this->mailer->AddAddress($to_splitted[3], $to_splitted[2]); 
 		} else {
-			$to = Email::validEmailAddress($to);
 			$this->mailer->ClearAddresses();
 			$this->mailer->AddAddress($to, ucfirst(substr($to, 0, strpos($to, '@')))); 
 			//For the recipient's name, the string before the @ from the e-mail address is used

--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -34,6 +34,7 @@ class SmtpMailer extends Mailer {
 			}
 			$this->mailer->SMTPDebug = defined('SMTPMAILER_DEBUG_MESSAGING_LEVEL') ? SMTPMAILER_DEBUG_MESSAGING_LEVEL : 0;
 			$this->mailer->SetLanguage(defined('SMTPMAILER_LANGUAGE_OF_MESSAGES') ? SMTPMAILER_LANGUAGE_OF_MESSAGES : 'en');
+			$this->mailer->ErrorLevel = defined('SMTPMAILER_SMTP_ERROR_LEVEL') ? SMTPMAILER_SMTP_ERROR_LEVEL : E_USER_ERROR;
 		}
 	}
 
@@ -101,9 +102,7 @@ class SmtpMailer extends Mailer {
 
 
 	function handleError($msg, $msgForLog){
-		echo $msg;
-		Debug::log($msg . $msgForLog);
-		die();
+		user_error($msg, $this->mailer->ErrorLevel);
 	}
 
 


### PR DESCRIPTION
Since this is a Silverstripe module , i think, the default errorhandling from silverstripe should be used 
http://doc.silverstripe.org/framework/en/topics/error-handling

The ErrorLevel can easily be set with
```
define('SMTPMAILER_SMTP_ERROR_LEVEL', E_USER_WARNING);
```

This also gives the developer the opportunity to prevent the smtp-module from breaking the site only because an error with the mailer occurred