### PR TITLE
Updated PHPMailer to 5.2.22 for security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Based on [http://silverstripe.org/smtpmailer-module/](http://silverstripe.org/sm
 ## Description
 **silverstripe-smtp** automatically sends emails (e.g. from UserForms) to your provider's or host's SMTP server instead of using PHP's built-in ``mail()`` function.
 
-**silverstripe-smtp** replaces the classic SilverStripe Mailer (using the ``mail()`` function) with PHPMailer 5.2.28 ([https://github.com/PHPMailer/PHPMailer](https://github.com/PHPMailer/PHPMailer), was [http://sourceforge.net/projects/phpmailer/](http://sourceforge.net/projects/phpmailer/)) to send emails via the SMTP protocol to a local or remote SMTP server.
+**silverstripe-smtp** replaces the classic SilverStripe Mailer (using the ``mail()`` function) with PHPMailer 5.2.22 ([https://github.com/PHPMailer/PHPMailer](https://github.com/PHPMailer/PHPMailer), was [http://sourceforge.net/projects/phpmailer/](http://sourceforge.net/projects/phpmailer/)) to send emails via the SMTP protocol to a local or remote SMTP server.
 
 When would you use this module:
 

--- a/code/vendor/class.smtp.php
+++ b/code/vendor/class.smtp.php
@@ -30,7 +30,7 @@ class SMTP
      * The PHPMailer SMTP version number.
      * @var string
      */
-    const VERSION = '5.2.21';
+    const VERSION = '5.2.22';
 
     /**
      * SMTP line break constant.
@@ -81,7 +81,7 @@ class SMTP
      * @deprecated Use the `VERSION` constant instead
      * @see SMTP::VERSION
      */
-    public $Version = '5.2.21';
+    public $Version = '5.2.22';
 
     /**
      * SMTP server port number.


### PR DESCRIPTION
Updates PHPMailer to 5.2.22 to address additional security issues [see here](https://github.com/PHPMailer/PHPMailer/releases/tag/v5.2.22), also adjusts the readme to match the current release of PHPMailer which is 5.2.22.